### PR TITLE
Add optional background to a map label

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,3 +12,4 @@
 Luke Mahé <lukem@google.com>
 Chris Broadfoot <cbro@google.com>
 Brendan Kenny <bckenny@google.com>
+Robert Howell <rhowell2@nd.edu>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -195,6 +195,31 @@
           <td><code><span class="type">number</span></code></td>
           <td>The zIndex of the label. Default is <code>1000</code>.</td>
         </tr>
+        <tr>
+          <td><code>backgroundColor</code></td>
+          <td><code><span class="type">number</span></code></td>
+          <td>The zIndex of the label. Default is <code>1000</code>.</td>
+        </tr>
+        <tr>
+          <td><code>backgroundStrokeWeight</code></td>
+          <td><code><span class="type">number</span></code></td>
+          <td>The zIndex of the label. Default is <code>1000</code>.</td>
+        </tr>
+        <tr>
+          <td><code>backgroundStrokeColor</code></td>
+          <td><code><span class="type">number</span></code></td>
+          <td>The zIndex of the label. Default is <code>1000</code>.</td>
+        </tr>
+        <tr>
+          <td><code>borderRadius</code></td>
+          <td><code><span class="type">number</span></code></td>
+          <td>The zIndex of the label. Default is <code>1000</code>.</td>
+        </tr>
+        <tr>
+          <td><code>padding</code></td>
+          <td><code><span class="type">number</span></code></td>
+          <td>The zIndex of the label. Default is <code>1000</code>.</td>
+        </tr>
       </tbody>
     </table>
   </body>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -197,28 +197,28 @@
         </tr>
         <tr>
           <td><code>backgroundColor</code></td>
-          <td><code><span class="type">number</span></code></td>
-          <td>The zIndex of the label. Default is <code>1000</code>.</td>
+          <td><code><span class="type">string</span></code></td>
+          <td>The background color. All CSS3 colors are supported. No background unless backgroundColor is specified.</td>
         </tr>
         <tr>
           <td><code>backgroundStrokeWeight</code></td>
           <td><code><span class="type">number</span></code></td>
-          <td>The zIndex of the label. Default is <code>1000</code>.</td>
+          <td>The background stroke width. Default is <code>1</code>.</td>
         </tr>
         <tr>
           <td><code>backgroundStrokeColor</code></td>
-          <td><code><span class="type">number</span></code></td>
-          <td>The zIndex of the label. Default is <code>1000</code>.</td>
+          <td><code><span class="type">string</span></code></td>
+          <td>The background stroke color. All CSS3 colors are supported. Default is <code>#FFFFFF</code>.</td>
         </tr>
         <tr>
           <td><code>borderRadius</code></td>
           <td><code><span class="type">number</span></code></td>
-          <td>The zIndex of the label. Default is <code>1000</code>.</td>
+          <td>The border radius on all corners of the background. Default is <code>0</code>.</td>
         </tr>
         <tr>
           <td><code>padding</code></td>
           <td><code><span class="type">number</span></code></td>
-          <td>The zIndex of the label. Default is <code>1000</code>.</td>
+          <td>The padding on all sides between the text and the background. Default is <code>0</code>.</td>
         </tr>
       </tbody>
     </table>

--- a/examples/maplabel-background.html
+++ b/examples/maplabel-background.html
@@ -3,14 +3,14 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
-    <title>Map Label Utility Library Example</title>
+    <title>Map Label Utility Library Example With Background</title>
     <style>
       body {
         font-family: sans-serif;
       }
     </style>
     <script src="https://maps.googleapis.com/maps/api/js"></script>
-    <script src="../src/maplabel-compiled.js"></script>
+    <script src="../src/maplabel.js"></script>
 
     <script>
       function init() {
@@ -24,11 +24,18 @@
         var map = new google.maps.Map(document.getElementById('map'), myOptions);
 
         var mapLabel = new MapLabel({
-          text: 'Test',
+          text: 'Background!',
           position: new google.maps.LatLng(34.03, -118.235),
           map: map,
-          fontSize: 35,
-          align: 'right'
+		  fontSize: 20,
+		  fontColor: '#fff',
+		  strokeWeight: 1.0,
+		  strokeColor: '#01579B',
+          backgroundColor: '#0288D1',
+          borderRadius: 10,
+          padding: 10,
+          backgroundStrokeColor: '#01579B',
+          backgroundStrokeWeight: 3
         });
         mapLabel.set('position', new google.maps.LatLng(34.03, -118.235));
 
@@ -39,37 +46,11 @@
 
         var map2 = new google.maps.Map(document.getElementById('map2'), myOptions);
 
-        var changeAlign = document.getElementById('change-align');
-        google.maps.event.addDomListener(changeAlign, 'click', function() {
-          mapLabel.set('align', document.getElementById('align').value);
-        });
-
-        var changeFont = document.getElementById('change-font');
-        google.maps.event.addDomListener(changeFont, 'click', function() {
-          mapLabel.set('fontSize', document.getElementById('font').value);
-        });
-
-        var changeColor = document.getElementById('change-color');
-        google.maps.event.addDomListener(changeColor, 'click', function() {
-          mapLabel.set('fontColor', document.getElementById('font-color').value);
-        });
-
         var changeText = document.getElementById('change-text');
         google.maps.event.addDomListener(changeText, 'click', function() {
           mapLabel.set('text', document.getElementById('text').value);
         });
 
-        var changeStrokeWeight = document.getElementById('change-strokeweight');
-        google.maps.event.addDomListener(changeStrokeWeight, 'click', function() {
-          mapLabel.set('strokeWeight',
-            document.getElementById('stroke-weight').value);
-        });
-
-        var changeStrokeColor = document.getElementById('change-strokecolor');
-        google.maps.event.addDomListener(changeStrokeColor, 'click', function() {
-          mapLabel.set('strokeColor',
-            document.getElementById('stroke-color').value);
-        });
 
         var move = document.getElementById('move');
         google.maps.event.addDomListener(move, 'click', function() {
@@ -92,45 +73,16 @@
     </script>
   </head>
   <body>
-    <h1>Map Label Utility Library</h1>
+    <h1>Map Label Utility Library - With Background</h1>
     <div id="map" style="width: 500px; height: 500px; float: left"></div>
     <div id="map2" style="width: 500px; height: 500px; float: left; margin-left: 20px;"></div>
     <div style="clear: both; padding-top: 10px;">
       <label>Map:</label>
       <button id="move">Toggle Maps</button>
     </div>
-    <div>
-      <label>Font Size:</label>
-      <input type="text" id="font" value="15">px
-      <button id="change-font">Change Size</button>
-    </div>
-    <div>
-      <label>Font Color:</label>
-      #<input type="text" id="font-color" value="ff0000">
-      <button id="change-color">Change Color</button>
-    </div>
-    <div>
-      <label>Stroke Weight:</label>
-      <input type="text" id="stroke-weight" value="3">px
-      <button id="change-strokeweight">Change Weight</button>
-    </div>
-    <div>
-      <label>Stroke Color:</label>
-      #<input type="text" id="stroke-color" value="8ada55">
-      <button id="change-strokecolor">Change Color</button>
-    <div>
       <label>Text:</label>
       <input type="text" id="text" value="foo">
       <button id="change-text">Change Text</button>
-    </div>
-    <div>
-      <label>Alignment:</label>
-      <select id="align">
-        <option value="left">Left</option>
-        <option value="center">Center</option>
-        <option value="right">Right</option>
-      </select>
-      <button id="change-align">Align</button>
     </div>
   </body>
 </html>

--- a/src/maplabel.js
+++ b/src/maplabel.js
@@ -40,6 +40,7 @@ function MapLabel(opt_options) {
   this.set('padding', 0);
   // Canvas sets lineWidth as 1.0 by default
   this.set('backgroundStrokeWeight', 1);
+  this.set('backgroundStrokeColor', '#ffffff');
   this.set('borderRadius', 0);
 
   this.set('zIndex', 1e3);


### PR DESCRIPTION
*See updated doc/reference.html.*
*See added examples/maplabel-background.html*

**Added:**
- backgroundColor
- backgroundStrokeColor
- backgroundStrokeWeight
- padding
- borderRadius

Not specifying a backgroundColor will cause the map label to operate exactly as before. **I have given the above additions sensible defaults,** but feel free to critic and change. Also, I did not add redraw on update of any of the follow added properties. If you feel like that is needed to complete this pull request, then I will add and test.

Best,
rchowell